### PR TITLE
Use finest granularity possible on BSD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,7 +508,7 @@ mod tests {
             .expect("periodic timer can be created");
         timer.reset(time::Duration::new(0, 5_000_000))
             .expect("reset works");
-        // run one iteration, so in case reset worked incrrectly and set up two timers,
+        // run one iteration, so in case reset worked incorrectly and set up two timers,
         // timer would then fire in a pattern of `a-b-[32ms of a]-b-[32ms of a]-b-...` and test
         // would fail
         timer = core.run(timer.into_future()).map_err(|(a, _)| a).unwrap().1;


### PR DESCRIPTION
I honestly don't know how exactly this fixes things, however it resolves two test failures on macOS (El Capitan) for me (on a MacBook Pro):

* `reset_works` would hang during the first `core.run` unless the reset duration was increased to at least 10ms
* `*works` would fail because `absdiff` was about 28ms